### PR TITLE
Update link to pings page

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -58,7 +58,7 @@
     </div>
     <div class="footer text-center">
       <p>Charcoal is not affiliated with or sponsored by Stack Exchange, Inc.<br />
-        <a href="/security">Security</a> • <a href="/pings">Contact</a>
+        <a href="/security">Security</a> • <a href="/pings/">Contact</a>
       </p>
       <p>
         <a href="{{ site.github.repository_url }}">Website Source</a>


### PR DESCRIPTION
At the moment, this link is broken because there is a redirect to an http, causing problems with our script, by rewriting the url to end with a slash we can avoid the following error:

    (index):1 Mixed Content: The page at 'https://charcoal-se.org/pings/' was loaded over HTTPS, but requested an insecure XMLHttpRequest endpoint 'http://charcoal-se.org/pings/'. This request has been blocked; the content must be served over HTTPS.